### PR TITLE
Es6 backtick XSS

### DIFF
--- a/lib/esapi.js
+++ b/lib/esapi.js
@@ -241,6 +241,7 @@ entityToCharacterMap["&quot"]        = "34";      /* 34 : quotation mark */
 entityToCharacterMap["&amp"]         = "38";      /* 38 : ampersand */
 entityToCharacterMap["&lt"]          = "60";        /* 60 : less-than sign */
 entityToCharacterMap["&gt"]          = "62";        /* 62 : greater-than sign */
+entityToCharacterMap["&#96"]         = "96";        /* 96 : back-tick */
 entityToCharacterMap["&nbsp"]        = "160";      /* 160 : no-break space */
 entityToCharacterMap["&iexcl"]       = "161";     /* 161 : inverted exclamation mark */
 entityToCharacterMap["&cent"]			= "162";	/* 162  : cent sign */

--- a/test/test.js
+++ b/test/test.js
@@ -3,7 +3,7 @@ var ESAPI = require('../lib/esapi');
 
 describe('ESAPI', function(){
     it('should encodeForHTML',function(){
-        assert.equal(ESAPI.encoder().encodeForHTML('< > " \' / &'), '&lt; &gt; &quot; &#x27; &#x2f; &amp;');
+        assert.equal(ESAPI.encoder().encodeForHTML('< > " \' / & `'), '&lt; &gt; &quot; &#x27; &#x2f; &amp; &#96;');
     });
     it('should encodeForHTMLAttribute',function(){
         assert.equal(ESAPI.encoder().encodeForHTMLAttribute(' % * + , - / ; < = > ^ and |'), ' &#x25; &#x2a; &#x2b; , - &#x2f; &#x3b; &lt; &#x3d; &gt; &#x5e; and &#x7c;');

--- a/test/test.js
+++ b/test/test.js
@@ -3,10 +3,10 @@ var ESAPI = require('../lib/esapi');
 
 describe('ESAPI', function(){
     it('should encodeForHTML',function(){
-        assert.equal(ESAPI.encoder().encodeForHTML('< > " \' / &'), '&lt; &gt; &quot; &#x27; &#x2f; &amp;');
+        assert.equal(ESAPI.encoder().encodeForHTML('< > " \' / & `'), '&lt; &gt; &quot; &#x27; &#x2f; &amp; &#96;');
     });
     it('should encodeForHTMLAttribute',function(){
-        assert.equal(ESAPI.encoder().encodeForHTMLAttribute(' % * + , - / ; < = > ^ and |'), ' &#x25; &#x2a; &#x2b; , - &#x2f; &#x3b; &lt; &#x3d; &gt; &#x5e; and &#x7c;');
+        assert.equal(ESAPI.encoder().encodeForHTMLAttribute(' % * + , - / ; < = > ^ and | `'), ' &#x25; &#x2a; &#x2b; , - &#x2f; &#x3b; &lt; &#x3d; &gt; &#x5e; and &#x7c; &#96;');
     });
     it('should encodeForJavaScript',function(){
         assert.equal(ESAPI.encoder().encodeForJavaScript('[space] % * + , - / ; < = > ^ and |. Also, a </script>'), '\\x5Bspace\\x5D\\x20\\x25\\x20\\x2A\\x20\\x2B\\x20,\\x20\\x2D\\x20\\x2F\\x20\\x3B\\x20\\x3C\\x20\\x3D\\x20\\x3E\\x20\\x5E\\x20and\\x20\\x7C.\\x20Also,\\x20a\\x20\\x3C\\x2Fscript\\x3E');


### PR DESCRIPTION
With browsers implementing es6, or soon to be implementing template strings, I believe it is necessary to include the backtick `in the html escaping to prevent XSS of the form alert`1` and the like.

I don't know if it is necessary to add the ` to the base64 test case but I added it to the others.
