### PR TITLE
fix: add MIT license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
         "xss",
         "encoding"
     ],
+    "license": "MIT",
     "version": "0.0.1",
     "repository": {
         "type": "git",


### PR DESCRIPTION
Fixes #5 to add a license to package.json

Note: after merging we need to also trigger an npm publish to release a new patch version to the registry too